### PR TITLE
Add plain JSON string encoding entry points (encodeJson) and docs/tests (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to Semantic Versioning and follows a Keep a Changelog-like format.
+
+## [0.1.1] - 2025-10-30
+
+### Added
+
+- `JToon.encodeJson(String)` and `JToon.encodeJson(String, EncodeOptions)` to encode plain JSON strings directly to TOON.
+- Centralized JSON parsing via `JsonNormalizer.parse(String)` to preserve separation of concerns.
+- Unit tests for JSON string entry point (objects, primitive arrays, tabular arrays, custom options, error cases).
+- README examples for JSON-string encoding, including a Java text block example.
+- This changelog.
+
+### Changed
+
+- README: Expanded API docs to include `encodeJson` overloads.
+
+## [0.1.0] - 2025-10-30
+
+### Added
+
+- Initial release.
+- Core encoding of Java objects to TOON with automatic normalization of Java types (numbers, temporals, collections, maps, arrays, POJOs).
+- Tabular array encoding for uniform arrays of objects.
+- Delimiter options (comma, tab, pipe) and optional length marker.
+- Comprehensive README with specification overview and examples.
+
+[0.1.1]: https://github.com/felipestanzani/jtoon/releases/tag/v0.1.1
+[0.1.0]: https://github.com/felipestanzani/jtoon/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ Number normalization examples:
 
 ### `JToon.encode(Object value, EncodeOptions options): String`
 
-Converts any Java object to TOON format.
+### `JToon.encodeJson(String json): String`
+
+### `JToon.encodeJson(String json, EncodeOptions options): String`
+
+Converts any Java object or JSON-string to TOON format.
 
 **Parameters:**
 
@@ -198,6 +202,10 @@ Converts any Java object to TOON format.
   - `indent` – Number of spaces per indentation level (default: `2`)
   - `delimiter` – Delimiter enum for array values and tabular rows: `Delimiter.COMMA` (default), `Delimiter.TAB`, or `Delimiter.PIPE`
   - `lengthMarker` – Boolean to prefix array lengths with `#` (default: `false`)
+
+For `encodeJson` overloads:
+
+- `json` – A valid JSON string to be parsed and encoded. Invalid or blank JSON throws `IllegalArgumentException`.
 
 **Returns:**
 
@@ -225,6 +233,30 @@ System.out.println(JToon.encode(data));
 items[2]{sku,qty,price}:
   A1,2,9.99
   B2,1,14.5
+```
+
+#### Encode a plain JSON string
+
+```java
+String json = """
+{
+  "user": {
+    "id": 123,
+    "name": "Ada",
+    "tags": ["reading", "gaming"]
+  }
+}
+""";
+System.out.println(JToon.encodeJson(json));
+```
+
+Output:
+
+```
+user:
+  id: 123
+  name: Ada
+  tags[2]: reading,gaming
 ```
 
 #### Delimiter Options
@@ -319,6 +351,7 @@ System.out.println(JToon.encode(data, new EncodeOptions(2, Delimiter.PIPE, true)
 ## See Also
 
 - **[TOON Format Specification](TOON-SPECIFICATION.md)** – Complete format rules, benchmarks, and examples
+- **[Changelog](CHANGELOG.md)** – Version history and notable changes
 
 ## Implementations in Other Languages
 

--- a/src/main/java/com/felipestanzani/jtoon/JToon.java
+++ b/src/main/java/com/felipestanzani/jtoon/JToon.java
@@ -25,6 +25,9 @@ import com.felipestanzani.jtoon.normalizer.JsonNormalizer;
  * // Encode pre-parsed JSON
  * JsonNode json = objectMapper.readTree(jsonString);
  * String result = JToon.encode(json);
+ * 
+ * // Encode a plain JSON string directly
+ * String result = JToon.encodeJson("{\"id\":123,\"name\":\"Ada\"}");
  * }</pre>
  */
 public final class JToon {
@@ -63,5 +66,41 @@ public final class JToon {
     public static String encode(Object input, EncodeOptions options) {
         JsonNode normalizedValue = JsonNormalizer.normalize(input);
         return ValueEncoder.encodeValue(normalizedValue, options);
+    }
+
+    /**
+     * Encodes a plain JSON string to TOON format using default options.
+     *
+     * <p>
+     * This is a convenience overload that parses the JSON string and encodes it
+     * without requiring callers to create a {@code JsonNode} or intermediate
+     * objects.
+     * </p>
+     *
+     * @param json The JSON string to encode (must be valid JSON)
+     * @return The TOON-formatted string
+     * @throws IllegalArgumentException if the input is not valid JSON
+     */
+    public static String encodeJson(String json) {
+        return encodeJson(json, EncodeOptions.DEFAULT);
+    }
+
+    /**
+     * Encodes a plain JSON string to TOON format using custom options.
+     *
+     * <p>
+     * Parsing is delegated to
+     * {@link com.felipestanzani.jtoon.normalizer.JsonNormalizer#parse(String)}
+     * to maintain separation of concerns.
+     * </p>
+     *
+     * @param json    The JSON string to encode (must be valid JSON)
+     * @param options Encoding options (indent, delimiter, length marker)
+     * @return The TOON-formatted string
+     * @throws IllegalArgumentException if the input is not valid JSON
+     */
+    public static String encodeJson(String json, EncodeOptions options) {
+        JsonNode parsed = JsonNormalizer.parse(json);
+        return ValueEncoder.encodeValue(parsed, options);
     }
 }

--- a/src/main/java/com/felipestanzani/jtoon/normalizer/JsonNormalizer.java
+++ b/src/main/java/com/felipestanzani/jtoon/normalizer/JsonNormalizer.java
@@ -31,6 +31,29 @@ public final class JsonNormalizer {
     }
 
     /**
+     * Parses a JSON string into a JsonNode using the shared ObjectMapper.
+     * <p>
+     * This centralizes JSON parsing concerns to keep the public API thin and
+     * maintain separation of responsibilities between parsing, normalization,
+     * and encoding.
+     * </p>
+     *
+     * @param json The JSON string to parse (must be non-blank)
+     * @return Parsed JsonNode
+     * @throws IllegalArgumentException if the input is blank or not valid JSON
+     */
+    public static JsonNode parse(String json) {
+        if (json == null || json.trim().isEmpty()) {
+            throw new IllegalArgumentException("Invalid JSON");
+        }
+        try {
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid JSON", e);
+        }
+    }
+
+    /**
      * Normalizes any Java object to a JsonNode.
      * 
      * @param value The value to normalize

--- a/src/test/java/com/felipestanzani/jtoon/JToonJsonStringTest.java
+++ b/src/test/java/com/felipestanzani/jtoon/JToonJsonStringTest.java
@@ -1,0 +1,81 @@
+package com.felipestanzani.jtoon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+@DisplayName("JToon.encodeJson - JSON string entry point")
+public class JToonJsonStringTest {
+
+    @Nested
+    @DisplayName("happy paths")
+    class HappyPaths {
+
+        @Test
+        @DisplayName("encodes simple object")
+        void encodesSimpleObject() {
+            String json = "{\"id\":123,\"name\":\"Ada\"}";
+            String result = JToon.encodeJson(json);
+            assertEquals("id: 123\nname: Ada", result);
+        }
+
+        @Test
+        @DisplayName("encodes primitive array inline")
+        void encodesPrimitiveArray() {
+            String json = "{\"tags\":[\"admin\",\"ops\",\"dev\"]}";
+            String result = JToon.encodeJson(json);
+            assertEquals("tags[3]: admin,ops,dev", result);
+        }
+
+        @Test
+        @DisplayName("encodes uniform objects as tabular array")
+        void encodesTabularArray() {
+            String json = "{\"items\":[{\"sku\":\"A1\",\"qty\":2,\"price\":9.99},{\"sku\":\"B2\",\"qty\":1,\"price\":14.5}]}";
+            String result = JToon.encodeJson(json);
+            String expected = String.join("\n",
+                    "items[2]{sku,qty,price}:",
+                    "  A1,2,9.99",
+                    "  B2,1,14.5");
+            assertEquals(expected, result);
+        }
+
+        @Test
+        @DisplayName("supports custom options with pipe delimiter and length marker")
+        void encodesWithCustomOptions() {
+            String json = "{\"tags\":[\"reading\",\"gaming\",\"coding\"],\"items\":[{\"sku\":\"A1\",\"qty\":2,\"price\":9.99},{\"sku\":\"B2\",\"qty\":1,\"price\":14.5}]}";
+            EncodeOptions options = new EncodeOptions(2, Delimiter.PIPE, true);
+            String result = JToon.encodeJson(json, options);
+
+            String expected = String.join("\n",
+                    "tags[#3|]: reading|gaming|coding",
+                    "items[#2|]{sku|qty|price}:",
+                    "  A1|2|9.99",
+                    "  B2|1|14.5");
+
+            assertEquals(expected, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("errors")
+    class Errors {
+
+        @Test
+        @DisplayName("throws on invalid JSON")
+        void throwsOnInvalidJson() {
+            assertThrows(IllegalArgumentException.class, () -> JToon.encodeJson("{invalid}"));
+        }
+
+        @Test
+        @DisplayName("throws on blank JSON")
+        void throwsOnBlankJson() {
+            assertThrows(IllegalArgumentException.class, () -> JToon.encodeJson("   \n \t  "));
+        }
+    }
+}
+
+


### PR DESCRIPTION
### Summary
This PR introduces convenience overloads to encode plain JSON strings directly to TOON, updates documentation with examples, centralizes JSON parsing, and adds tests. Version is bumped to 0.1.1.

### Motivation
- Simplify workflows where inputs are already JSON (strings), avoiding callers needing to parse into `JsonNode` first.
- Keep parsing concerns out of `JToon` by delegating to a centralized utility.

### Changes
- Added:
  - `JToon.encodeJson(String json): String`
  - `JToon.encodeJson(String json, EncodeOptions options): String`
  - Centralized parsing: `JsonNormalizer.parse(String)` with consistent validation and error handling.
  - Unit tests covering:
    - Objects, primitive arrays, tabular arrays
    - Custom `EncodeOptions` (indent, delimiter, lengthMarker)
    - Error cases (blank/invalid JSON)
  - README examples for `encodeJson`, including Java text block usage.
  - Changelog for 0.1.1.
- Updated:
  - README API section to document new overloads.
  - Version: 0.1.1.

### API
- New methods in `JToon`:
  - `encodeJson(String json)`
  - `encodeJson(String json, EncodeOptions options)`
- Internally delegates parsing to `JsonNormalizer.parse(String)` and encoding to `ValueEncoder.encodeValue(...)`.

### Behavior and Validation
- Blank or invalid JSON results in `IllegalArgumentException` from `JsonNormalizer.parse(String)`.
- Output format remains identical to `encode(...)` of equivalent structures.

### Breaking Changes
- None. Purely additive.

### Documentation
- README:
  - Adds `Encode a plain JSON string` example and explains delimiter options and length markers in context.
  - API list now includes both `encodeJson` overloads.
- CHANGELOG:
  - Adds 0.1.1 entry detailing new APIs, docs, and tests.

### Testing
- New tests validate:
  - Encoding JSON objects, primitive arrays, and tabular arrays via string inputs.
  - Custom delimiter and length marker options.
  - Error handling for invalid/blank JSON.
- Test reports are present under `build/reports/tests/test`.

### Versioning
- Bumps to 0.1.1 as per CHANGELOG. Artifacts and README badges remain consistent with release automation.

### Migration Guide
- For existing JSON-string-based callers:
  - Replace manual parsing + `encode(JsonNode)` with the new entry points:
```java
// Before
JsonNode node = objectMapper.readTree(jsonString);
String toon = JToon.encode(node);

// After
String toon = JToon.encodeJson(jsonString);
```
- For custom options:
```java
String toon = JToon.encodeJson(jsonString, new EncodeOptions(2, Delimiter.PIPE, true));
```

### Checklist
- [x] API additions documented in README
- [x] CHANGELOG updated to 0.1.1
- [x] Tests added and passing
- [x] No breaking changes introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `encodeJson()` methods to encode JSON strings directly to TOON format with optional encoding options and input validation.

* **Documentation**
  * Added CHANGELOG tracking version history and release notes.
  * Updated README with new API documentation and usage examples.

* **Tests**
  * Added unit tests covering JSON string encoding scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->