### PR TITLE
Fix: timezone-related test failures in JsonNormalizerTest (#83)

### DIFF
--- a/src/test/java/dev/toonformat/jtoon/normalizer/JsonNormalizerTest.java
+++ b/src/test/java/dev/toonformat/jtoon/normalizer/JsonNormalizerTest.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -345,7 +346,8 @@ class JsonNormalizerTest {
             java.sql.Time time = new java.sql.Time(1766419274);
             JsonNode result = JsonNormalizer.normalize(time);
             assertTrue(result.isString());
-            assertEquals("11:40:19", result.asString());
+            String expected = time.toLocalTime().format(DateTimeFormatter.ISO_LOCAL_TIME);
+            assertEquals(expected, result.asString());
         }
 
         @Test
@@ -354,7 +356,8 @@ class JsonNormalizerTest {
             java.sql.Timestamp dateTime = new java.sql.Timestamp(1766419274);
             JsonNode result = JsonNormalizer.normalize(dateTime);
             assertTrue(result.isString());
-            assertEquals("1970-01-21T11:40:19.274", result.asString());
+            String expected = dateTime.toLocalDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            assertEquals(expected, result.asString());
         }
 
 
@@ -1191,7 +1194,8 @@ class JsonNormalizerTest {
 
             // Then
             assertInstanceOf(StringNode.class, result);
-            assertEquals("2017-02-16T19:22:28Z", ((JsonNode) result).asString());
+            String expected = input.toInstant().toString();
+            assertEquals(expected, ((JsonNode) result).asString());
         }
 
         @Test
@@ -1205,7 +1209,8 @@ class JsonNormalizerTest {
 
             // Then
             assertInstanceOf(StringNode.class, result);
-            assertEquals("2017-02-16T19:22:28Z", ((JsonNode) result).asString());
+            String expected = input.toInstant().toString();
+            assertEquals(expected, ((JsonNode) result).asString());
         }
 
         @Test


### PR DESCRIPTION
The JsonNormalizerTest in the JToon project contains 4 test cases related to time types that fail in my UTC+8 timezones because they use hardcoded expected values, while JsonNormalizer uses the system default timezone when processing SQL time types.

## Linked Issue

<!-- Reference the related issue. Example: Closes #123 -->

Closes #83 

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- List the main changes in this PR -->
For dev.toonformat.jtoon.normalizer.JsonNormalizerTest
- Replace hardcoded timezone values with dynamic computation based on system timezone
- Update testSQLTime to use time.toLocalTime().format(DateTimeFormatter.ISO_LOCAL_TIME)
- Update testSQLTimeStamp to use dateTime.toLocalDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
- Update Calendar and GregorianCalendar tests to use input.toInstant().toString()
- Add missing DateTimeFormatter import for time formatting


## Testing

<!-- Describe the tests you added or ran -->

- [x] All existing tests pass
- [ ] Added new tests for changes
- [ ] Tests cover edge cases and spec compliance

## Pre-submission Checklist

<!-- Verify before submitting -->

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->
